### PR TITLE
Fixed unstable unit test in FetchGraphComponent.

### DIFF
--- a/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graph.component.spec.ts
+++ b/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graph.component.spec.ts
@@ -60,9 +60,9 @@ describe("VymazatComponent", () => {
     });
 
     it("should get current time as ISO string", () => {
-        expect(component.getCurrentTimeAsIsoString()).toBe(
-            new Date().toISOString()
-        );
+        const currentDate: Date = new Date();
+        const currentDateISO = currentDate.toISOString();
+        expect(component.getCurrentTimeAsIsoString()).toBe(currentDateISO);
     });
 
     it("should get graph data latest sorted by month", () => {


### PR DESCRIPTION
-- The mismatch can hapeend because the creationg od new Date Object can take more than 1 second sometimes.
-- If the unstability will continue, the test should be adjusted again...