### PR TITLE
[BUG #9] - Fixed ability to move time to the future

### DIFF
--- a/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graph.component.spec.ts
+++ b/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graph.component.spec.ts
@@ -6,7 +6,7 @@ import { Observable, of } from "rxjs";
 import { FormatTypes } from "../services/switchable-date-picker-format/switchable-date-picker-format-service.service";
 import { FetchGraphsComponent } from "./fetch-graphs.component";
 
-describe("VymazatComponent", () => {
+describe("FetchGraphsComponent", () => {
     let component: FetchGraphsComponent;
     let fixture: ComponentFixture<FetchGraphsComponent>;
     let localStorageMock: { [key: string]: string } = {};
@@ -93,8 +93,10 @@ describe("VymazatComponent", () => {
     it("should move date by one day to the back", () => {
         component.activeSorting = SortTime.Hour;
         const date = new Date();
+        component.minDate = new Date(date.getTime());
+        component.minDate.setFullYear(date.getDate() - 1);
         component.relevantDate = date.toISOString();
-        component.moveDate(1);
+        component.moveDate(Direction.Left);
         date.setDate(date.getDate() - 1);
         const newDate = date.toISOString();
         expect(component.relevantDate).toBe(newDate);
@@ -103,8 +105,10 @@ describe("VymazatComponent", () => {
     it("should move date by one day to the front", () => {
         component.activeSorting = SortTime.Hour;
         const date = new Date();
+        component.maxDate = new Date(date.getTime());
+        component.maxDate.setDate(date.getDate() + 1);
         component.relevantDate = date.toISOString();
-        component.moveDate(2);
+        component.moveDate(Direction.Right);
         date.setDate(date.getDate() + 1);
         const newDate = date.toISOString();
         expect(component.relevantDate).toBe(newDate);
@@ -117,7 +121,7 @@ describe("VymazatComponent", () => {
         minDate.setHours(minDate.getHours() + 1);
         component.minDate = minDate;
         component.relevantDate = date.toISOString();
-        component.moveDate(1);
+        component.moveDate(Direction.Left);
         expect(component.relevantDate).toBe(date.toISOString());
     });
 
@@ -127,15 +131,17 @@ describe("VymazatComponent", () => {
         const maxDate = new Date(date);
         component.maxDate = maxDate;
         component.relevantDate = date.toISOString();
-        component.moveDate(2);
+        component.moveDate(Direction.Right);
         expect(component.relevantDate).toBe(date.toISOString());
     });
 
     it("should move date by one month to the back", () => {
         component.activeSorting = SortTime.Day;
         const date = new Date();
+        component.minDate = new Date(date.getTime());
+        component.minDate.setMonth(date.getMonth() - 1);
         component.relevantDate = date.toISOString();
-        component.moveDate(1);
+        component.moveDate(Direction.Left);
         date.setMonth(date.getMonth() - 1);
         const newDate = date.toISOString();
         expect(component.relevantDate).toBe(newDate);
@@ -143,9 +149,11 @@ describe("VymazatComponent", () => {
 
     it("should move date by one year to the back", () => {
         component.activeSorting = SortTime.Month;
-        const date = new Date();
+        const date: Date = new Date();
+        component.minDate = new Date(date.getTime());
+        component.minDate.setFullYear(date.getFullYear() - 1);
         component.relevantDate = date.toISOString();
-        component.moveDate(1);
+        component.moveDate(Direction.Left);
         date.setFullYear(date.getFullYear() - 1);
         const newDate = date.toISOString();
         expect(component.relevantDate).toBe(newDate);
@@ -155,7 +163,7 @@ describe("VymazatComponent", () => {
         component.activeSorting = SortTime.Year;
         const date = new Date();
         component.relevantDate = date.toISOString();
-        component.moveDate(0);
+        component.moveDate(Direction.None);
         expect(component.relevantDate).toBe(date.toISOString());
     });
 
@@ -194,5 +202,11 @@ describe("VymazatComponent", () => {
         Month = "month",
         Day = "day",
         Hour = "hour",
+    }
+
+    enum Direction {
+        None = 0,
+        Left = 1,
+        Right = 2,
     }
 });

--- a/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graphs.component.ts
+++ b/TeamspeakStatsNew/TeamspeakStatsNew/ClientApp/src/app/fetch-graphs/fetch-graphs.component.ts
@@ -90,19 +90,24 @@ export class FetchGraphsComponent implements OnInit {
         const date: Date = new Date(this.relevantDate);
         switch (direction) {
             case Direction.Left:
-                if (date < this.minDate) {
+                if (this.compareDatesNoTime(date, this.minDate) !== 1) {
+                    // If the date is < this.minDate
                     return;
                 }
                 moveByAmount = -1;
                 break;
             case Direction.Right:
-                if (date >= this.maxDate) {
+                if (this.compareDatesNoTime(date, this.maxDate) !== -1) {
+                    // If the date is > this.maxDate
                     return;
                 }
                 moveByAmount = 1;
                 break;
             default:
         }
+
+        console.log(date);
+        console.log(this.maxDate);
 
         switch (this.activeSorting) {
             case SortTime.Hour:
@@ -216,7 +221,43 @@ export class FetchGraphsComponent implements OnInit {
         if (event.toISOString() !== this.previousDate) {
             this.getGraphData(this.activeSorting, this.relevantDate);
             this.previousDate = this.relevantDate;
+            console.log(this.maxDate);
+            console.log(this.relevantDate);
         }
+    }
+
+    private compareDatesNoTime(date1: Date, date2: Date): number {
+        const compareYears = this.compareNumber(
+            date1.getFullYear(),
+            date2.getFullYear()
+        );
+
+        if (compareYears === 0) {
+            const compareMonths = this.compareNumber(
+                date1.getMonth(),
+                date2.getMonth()
+            );
+
+            if (compareMonths === 0) {
+                return this.compareNumber(date1.getDate(), date2.getDate());
+            }
+
+            return compareMonths;
+        }
+
+        return compareYears;
+    }
+
+    private compareNumber(number1: number, number2: number): number {
+        if (number1 < number2) {
+            return -1;
+        }
+
+        if (number1 > number2) {
+            return 1;
+        }
+
+        return 0;
     }
 }
 


### PR DESCRIPTION
-- Bug was caused in comparison
-- for example: maxDate had hours set to 20, and date to compare had 18, therefore it was still correct (in code), to move it forward, similiar for backward case. 
-- I fixed it by not comparing Smaller Units, but it could also be solved to compare units that are releated to moving time, e.g. if moving Years, compare only years, if Months - compare Years and Months....